### PR TITLE
Update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 2d40e03a453a531486e5a75a47c2aa281a73296a9fcdfefe9f95f720d0b1667e
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - cfn-lint = cfnlint.__main__:main
@@ -19,20 +19,18 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.7
     - pip
   run:
-    - python >=3.6
-    - aws-sam-translator >=1.40.0
-    - importlib_resources >=1.4,<4
+    - python >=3.7
+    - aws-sam-translator >=1.55.0
     - jschema-to-python ~=1.2.3
     - jsonpatch
-    - jsonschema ~=3.0
+    - jsonschema >=3.0,<5
     - junit-xml ~=1.9
     - networkx ~=2.4
     - pyyaml >5.4
     - sarif-om ~=1.0.4
-    - six >=1.11
 
 test:
   imports:


### PR DESCRIPTION
Dependencies are out of date, and as a consequence you can't install `moto` in the same environment as `jupyterlab` due to the `jsonschema >=4.3` requirement there and the `~=3` here.

https://github.com/aws-cloudformation/cfn-lint/blob/main/setup.py

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
