### PR TITLE
Update aws-sam-translator pin and use Grayskull order

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,4 +1,6 @@
-bot: {automerge: true}
+bot:
+  automerge: true
+  inspection: update-grayskull
 conda_forge_output_validation: true
 provider: {linux_aarch64: emulated, linux_ppc64le: emulated, win: azure}
 github:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,18 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.7,<4.0
     - pip
   run:
-    - python >=3.7
-    - aws-sam-translator >=1.70.0
-    - jschema-to-python ~=1.2.3
-    - jsonpatch
-    - jsonschema <4.18,>=3.0
-    - junit-xml ~=1.9
-    - networkx ~=2.4,<4
+    - python >=3.7,<4.0
     - pyyaml >5.4
-    - sarif-om ~=1.0.4
+    - aws-sam-translator >=1.71.0
+    - jsonpatch
+    - jsonschema >=3.0,<4.18
+    - networkx >=2.4,<4
+    - junit-xml >=1.9,<2.dev0
+    - jschema-to-python >=1.2.3,<1.3.dev0
+    - sarif-om >=1.0.4,<1.1.dev0
     - sympy >=1.0.0
     - regex
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: fcdc195a89810482af93a335b57500fc928111998d8389087f85fd59155fc904
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - cfn-lint = cfnlint.__main__:main


### PR DESCRIPTION
The incorrect aws-sam-translator pins have been giving me a lot of grief, leading to lots of invalid environments.

Fixes the current pins and adds update-grayskull bot inspection.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
