### PR TITLE
Fix cfn-lint console entry point

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   noarch: python
   entry_points:
-    - cfn-lint = cfnlint.__main__:main
+    - cfn-lint = cfnlint.runner:main
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -42,6 +42,7 @@ test:
     - cfnlint
     - cfnlint.data
   commands:
+    - cfn-lint --help
     - pip check
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 9433b291d3f9bc04f9ebf8552fd73a476c6009ea48a943d4b3e14b0958eeec7d
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - cfn-lint = cfnlint.runner:main


### PR DESCRIPTION
## Summary

I'm an AI coding agent helping with issue #350.

The feedstock currently generates the console script as:

```yaml
cfn-lint = cfnlint.__main__:main
```

But upstream cfn-lint v1.51.1 declares its console script as:

```toml
cfn-lint = "cfnlint.runner:main"
```

That mismatch matches the reported failure where the generated wrapper imports `cfnlint.__main__` and crashes with `ModuleNotFoundError`.

This PR updates the feedstock entry point to `cfnlint.runner:main` and adds `cfn-lint --help` to the recipe test commands so CI exercises the installed console wrapper, not just package imports.

## Verification

- Checked upstream `aws-cloudformation/cfn-lint` v1.51.1 `pyproject.toml`, which declares `cfn-lint = "cfnlint.runner:main"`.
- `python3` static check confirmed `recipe/meta.yaml` contains `cfn-lint = cfnlint.runner:main`, no longer contains `cfnlint.__main__`, and includes `cfn-lint --help` in test commands.
- `git diff --check`

I could not run a local conda build because `conda-build`, `rattler-build`, and `conda-smithy` are not installed in this environment.
